### PR TITLE
Convert lambda slot to ordinary connection

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -59,6 +59,8 @@ public slots:
     //Menu "Emulator"
     void restart();
     void openConfiguration();
+    void startKit();
+    void startKitDiags();
 
     //Menu "Tools"
     void screenshot();


### PR DESCRIPTION
- Workaround for LTO dropping the metaobject of QAction
- Fixes ".. with Kit" menus with LTO enabled